### PR TITLE
override4

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,6 +3,7 @@
   "scripts": {
   },
   "env": {
+    "TESTVAR":""
   },
   "formation": {
     "web": {


### PR DESCRIPTION
setting testvar explicitly to ""  without the value key pair (object notation)